### PR TITLE
Removed default type declarations in three templated functions

### DIFF
--- a/IntervalTree.h
+++ b/IntervalTree.h
@@ -21,17 +21,17 @@ public:
     { }
 };
 
-template <class T, typename K = int>
+template <class T, typename K>
 int intervalStart(const Interval<T,K>& i) {
     return i.start;
 }
 
-template <class T, typename K = int>
+template <class T, typename K>
 int intervalStop(const Interval<T,K>& i) {
     return i.stop;
 }
 
-template <class T, typename K = int>
+template <class T, typename K>
 ostream& operator<<(ostream& out, Interval<T,K>& i) {
     out << "Interval(" << i.start << ", " << i.stop << "): " << i.value;
     return out;


### PR DESCRIPTION
The default type declarations on the intervalStart(), intervalStop, and << operatior overload functions in IntervalTree.h were interfering with cmake's ability to link this into the vcflib project. 

The test ran and I assumed it passed, I got:

brute force:    972ms
interval tree:  31ms
