### PR TITLE
Fix incorrect behavior for small number of intervals.

### DIFF
--- a/IntervalTree.h
+++ b/IntervalTree.h
@@ -112,12 +112,13 @@ public:
     {
 
         --depth;
+        IntervalStartSorter<T,K> intervalStartSorter;
         if (depth == 0 || (ivals.size() < minbucket && ivals.size() < maxbucket)) {
+            sort(ivals.begin(), ivals.end(), intervalStartSorter);
             intervals = ivals;
         } else {
             if (leftextent == 0 && rightextent == 0) {
                 // sort intervals by start
-                IntervalStartSorter<T,K> intervalStartSorter;
                 sort(ivals.begin(), ivals.end(), intervalStartSorter);
             }
 

--- a/interval_tree_test.cpp
+++ b/interval_tree_test.cpp
@@ -28,11 +28,25 @@ Interval<T,K> randomInterval(K maxStart, K maxLength, K maxStop, const T& value)
 int main() {
     typedef vector<std::size_t> countsVector;
 
+    // a simple sanity check
+    intervalVector sanityIntervals;
+    sanityIntervals.push_back(interval(60, 80, true));
+    sanityIntervals.push_back(interval(20, 40, true));
+    intervalTree sanityTree(sanityIntervals);
+
+    intervalVector sanityResults;
+    sanityTree.findOverlapping(30, 50, sanityResults);
+    assert(sanityResults.size() == 1);
+    sanityResults.clear();
+    sanityTree.findContained(15, 45, sanityResults);
+    assert(sanityResults.size() == 1);
+     
+
     srand((unsigned)time(NULL));
 
     intervalVector intervals;
     intervalVector queries;
-
+    
     // generate a test set of target intervals
     for (int i = 0; i < 10000; ++i) {
         intervals.push_back(randomInterval<bool>(100000, 1000, 100000 + 1, true));


### PR DESCRIPTION
Currently, findOverlapping and findContained return incorrect results if the interval tree is created from a small number of unsorted intervals. The little sanity check in interval_tree_test would fail.
