### PR TITLE
fixed clang compilation error

### DIFF
--- a/interval_tree_test.cpp
+++ b/interval_tree_test.cpp
@@ -40,20 +40,20 @@ int main() {
     sanityResults.clear();
     sanityTree.findContained(15, 45, sanityResults);
     assert(sanityResults.size() == 1);
-     
+
 
     srand((unsigned)time(NULL));
 
     intervalVector intervals;
     intervalVector queries;
-    
+
     // generate a test set of target intervals
     for (int i = 0; i < 10000; ++i) {
-        intervals.push_back(randomInterval<bool>(100000, 1000, 100000 + 1, true));
+        intervals.push_back(randomInterval<bool, unsigned long>(100000, 1000, 100000 + 1, true));
     }
     // and queries
     for (int i = 0; i < 5000; ++i) {
-        queries.push_back(randomInterval<bool>(100000, 1000, 100000 + 1, true));
+        queries.push_back(randomInterval<bool, unsigned long>(100000, 1000, 100000 + 1, true));
     }
 
     typedef chrono::high_resolution_clock Clock;


### PR DESCRIPTION
with clang 6.1.0 on OS X there is a little error.
```
Apple LLVM version 6.1.0 (clang-602.0.53) (based on LLVM 3.6.0svn)
Target: x86_64-apple-darwin14.5.0
Thread model: posix
```

Here is the error:
```cpp
interval_tree_test.cpp:52:19: error: no matching member function for call to 'push_back'
        intervals.push_back(randomInterval<bool>(100000, 1000, 100000 + 1, true));
        ~~~~~~~~~~^~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/vector:697:36: note:
      candidate function not viable: no known conversion from 'Interval<[...], int>' to 'const Interval<[...], unsigned long>'
      for 1st argument
    _LIBCPP_INLINE_VISIBILITY void push_back(const_reference __x);
                                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/vector:699:36: note:
      candidate function not viable: no known conversion from 'Interval<[...], int>' to 'Interval<[...], unsigned long>' for 1st
      argument
    _LIBCPP_INLINE_VISIBILITY void push_back(value_type&& __x);
```