### PR TITLE
Replace hard-coded compiler for portability.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
+
+CXX ?=		g++
+CXXFLAGS ?=	-Wall
+
 interval_tree_test: interval_tree_test.cpp IntervalTree.h
-	g++ -Wall interval_tree_test.cpp -o interval_tree_test -std=c++0x
+	${CXX} ${CXXFLAGS} interval_tree_test.cpp -o interval_tree_test -std=c++0x
 
 .PHONY: clean
 


### PR DESCRIPTION

Makefile changes to allow overriding compiler and flags from the env or command-line.

Default behavior should remain the same.