### PR TITLE
Add install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,29 @@
 
-CXX ?=		g++
+CXX ?=		c++
 CXXFLAGS ?=	-Wall
+DESTDIR ?=	stage
+PREFIX ?=	/usr/local
+MKDIR ?=	mkdir
+INSTALL ?=	install -c
+STRIP ?=	strip
 
-interval_tree_test: interval_tree_test.cpp IntervalTree.h
-	${CXX} ${CXXFLAGS} interval_tree_test.cpp -o interval_tree_test -std=c++0x
+BIN =	interval_tree_test
+
+all: ${BIN}
+
+${BIN}: interval_tree_test.cpp IntervalTree.h
+	${CXX} ${CXXFLAGS} interval_tree_test.cpp -std=c++0x -o ${BIN}
+
+install:
+	${MKDIR} -p ${DESTDIR}${PREFIX}/bin
+	${MKDIR} -p ${DESTDIR}${PREFIX}/include
+	${INSTALL} ${BIN} ${DESTDIR}${PREFIX}/bin
+	${INSTALL} IntervalTree.h ${DESTDIR}${PREFIX}/include
+
+install-strip: install
+	${STRIP} ${DESTDIR}${PREFIX}/bin/${BIN}
 
 .PHONY: clean
 
 clean:
-	rm interval_tree_test
+	rm -rf ${BIN} ${DESTDIR}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
 
+# Use ?= to allow overriding from the env or command-line, e.g.
+#
+#	make CXXFLAGS="-O3 -fPIC" install
+#
+# Package managers will override many of these variables automatically, so
+# this is aimed at making it easy to create packages (Debian packages,
+# FreeBSD ports, MacPorts, pkgsrc, etc.)
+
 CXX ?=		c++
 CXXFLAGS ?=	-Wall
 DESTDIR ?=	stage

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ ${BIN}: interval_tree_test.cpp IntervalTree.h
 
 install:
 	${MKDIR} -p ${DESTDIR}${PREFIX}/bin
-	${MKDIR} -p ${DESTDIR}${PREFIX}/include
+	${MKDIR} -p ${DESTDIR}${PREFIX}/include/intervaltree
 	${INSTALL} ${BIN} ${DESTDIR}${PREFIX}/bin
-	${INSTALL} IntervalTree.h ${DESTDIR}${PREFIX}/include
+	${INSTALL} IntervalTree.h ${DESTDIR}${PREFIX}/include/intervaltree
 
 install-strip: install
 	${STRIP} ${DESTDIR}${PREFIX}/bin/${BIN}

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: ${BIN}
 ${BIN}: interval_tree_test.cpp IntervalTree.h
 	${CXX} ${CXXFLAGS} interval_tree_test.cpp -std=c++0x -o ${BIN}
 
-install:
+install: all
 	${MKDIR} -p ${DESTDIR}${PREFIX}/bin
 	${MKDIR} -p ${DESTDIR}${PREFIX}/include/intervaltree
 	${INSTALL} ${BIN} ${DESTDIR}${PREFIX}/bin


### PR DESCRIPTION

Also changed default compiler from g++ to c++ for portability.  I believe they are the same on all GNU/Linux distributions.  On BSD and Mac, this will use Clang, which is highly compatible with GCC.  If there was some other reason to default to g++, I'm fine with that.

Either way, the compiler and flags can easily be overridden from the env or command-line.

    make CXX=g++ CXXFLAGS=-O3 install
