### PR TITLE
Fix memory leak

### DIFF
--- a/IntervalTree.h
+++ b/IntervalTree.h
@@ -64,22 +64,16 @@ public:
 
 private:
     std::unique_ptr<intervalTree> copyTree(intervalTree& orig){
-	return std::unique_ptr<intervalTree>(new intervalTree(orig));
+        return std::unique_ptr<intervalTree>(new intervalTree(orig));
     }
 public:
     
     IntervalTree<T,K>(const intervalTree& other) 
-        : left(nullptr)
-        , right(nullptr)
+    :   intervals(other.intervals),
+        left(other.left ? copyTree(*other.left) : nullptr),
+        right(other.right ? copyTree(*other.right) : nullptr),
+        center(other.center)
     {
-        center = other.center;
-        intervals = other.intervals;
-        if (other.left) {
-            left = copyTree(*other.left);
-        }
-        if (other.right) {
-            right = copyTree(*other.right);
-        }
     }
 
 public:
@@ -87,8 +81,8 @@ public:
     IntervalTree<T,K>& operator=(const intervalTree& other) {
         center = other.center;
         intervals = other.intervals;
-	left = other.left ? copyTree(*other.left) : nullptr;
-	right = other.right ? copyTree(*other.right) : nullptr;
+        left = other.left ? copyTree(*other.left) : nullptr;
+        right = other.right ? copyTree(*other.right) : nullptr;
         return *this;
     }
 

--- a/IntervalTree.h
+++ b/IntervalTree.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <algorithm>
 #include <iostream>
+#include <memory>
 
 template <class T, typename K = std::size_t>
 class Interval {
@@ -51,45 +52,43 @@ public:
     typedef IntervalTree<T,K> intervalTree;
     
     intervalVector intervals;
-    intervalTree* left;
-    intervalTree* right;
+    std::unique_ptr<intervalTree> left;
+    std::unique_ptr<intervalTree> right;
     K center;
 
     IntervalTree<T,K>(void)
-        : left(NULL)
-        , right(NULL)
+        : left(nullptr)
+        , right(nullptr)
         , center(0)
     { }
 
+private:
+    std::unique_ptr<intervalTree> copyTree(intervalTree& orig){
+	return std::unique_ptr<intervalTree>(new intervalTree(orig));
+    }
+public:
+    
     IntervalTree<T,K>(const intervalTree& other) 
-        : left(NULL)
-        , right(NULL)
+        : left(nullptr)
+        , right(nullptr)
     {
         center = other.center;
         intervals = other.intervals;
         if (other.left) {
-            left = new intervalTree(*other.left);
+            left = copyTree(*other.left);
         }
         if (other.right) {
-            right = new intervalTree(*other.right);
+            right = copyTree(*other.right);
         }
     }
 
+public:
+    
     IntervalTree<T,K>& operator=(const intervalTree& other) {
         center = other.center;
         intervals = other.intervals;
-        if (other.left) {
-            left = new intervalTree(*other.left);
-        } else {
-            if (left) delete left;
-            left = NULL;
-        }
-        if (other.right) {
-            right = new intervalTree(*other.right);
-        } else {
-            if (right) delete right;
-            right = NULL;
-        }
+	left = other.left ? copyTree(*other.left) : nullptr;
+	right = other.right ? copyTree(*other.right) : nullptr;
         return *this;
     }
 
@@ -101,8 +100,8 @@ public:
             K rightextent = 0,
             std::size_t maxbucket = 512
             )
-        : left(NULL)
-        , right(NULL)
+        : left(nullptr)
+        , right(nullptr)
     {
 
         --depth;
@@ -150,10 +149,10 @@ public:
             }
 
             if (!lefts.empty()) {
-                left = new intervalTree(lefts, depth, minbucket, leftp, centerp);
+                left = std::unique_ptr<intervalTree>(new intervalTree(lefts, depth, minbucket, leftp, centerp));
             }
             if (!rights.empty()) {
-                right = new intervalTree(rights, depth, minbucket, centerp, rightp);
+                right = std::unique_ptr<intervalTree>(new intervalTree(rights, depth, minbucket, centerp, rightp));
             }
         }
     }
@@ -198,16 +197,7 @@ public:
 
     }
 
-    ~IntervalTree(void) {
-        // traverse the left and right
-        // delete them all the way down
-        if (left) {
-            delete left;
-        }
-        if (right) {
-            delete right;
-        }
-    }
+    ~IntervalTree(void) = default;
 
 };
 

--- a/IntervalTree.h
+++ b/IntervalTree.h
@@ -50,7 +50,7 @@ public:
     typedef Interval<T,K> interval;
     typedef std::vector<interval> intervalVector;
     typedef IntervalTree<T,K> intervalTree;
-    
+
     intervalVector intervals;
     std::unique_ptr<intervalTree> left;
     std::unique_ptr<intervalTree> right;
@@ -67,8 +67,8 @@ private:
         return std::unique_ptr<intervalTree>(new intervalTree(orig));
     }
 public:
-    
-    IntervalTree<T,K>(const intervalTree& other) 
+
+    IntervalTree<T,K>(const intervalTree& other)
     :   intervals(other.intervals),
         left(other.left ? copyTree(*other.left) : nullptr),
         right(other.right ? copyTree(*other.right) : nullptr),
@@ -77,7 +77,7 @@ public:
     }
 
 public:
-    
+
     IntervalTree<T,K>& operator=(const intervalTree& other) {
         center = other.center;
         intervals = other.intervals;
@@ -112,7 +112,7 @@ public:
             K leftp = 0;
             K rightp = 0;
             K centerp = 0;
-            
+
             if (leftextent || rightextent) {
                 leftp = leftextent;
                 rightp = rightextent;


### PR DESCRIPTION
I fixed a memory leak by moving to unique_ptr and also moved the initialization in the constructors to their initialization lists.

I considered having conditional compilation for C++98 to use auto_ptr, but the makefile specifies C++0x so I decided against it.