### PR TITLE
reverse order to fix gcc parse bug (closes #17)

### DIFF
--- a/IntervalTree.h
+++ b/IntervalTree.h
@@ -134,7 +134,7 @@ public:
 
             for (typename intervalVector::const_iterator i = ivals.begin(); i != ivals.end(); ++i) {
                 const interval& interval = *i;
-                if (interval.stop < center) {
+                if (center > interval.stop) {
                     lefts.push_back(interval);
                 } else if (interval.start > center) {
                     rights.push_back(interval);


### PR DESCRIPTION
This fixes a known gcc parser bug that croaks on `<` comparisons, which it sometimes thinks are malformed template args. This bug is fixed in gcc >= 6.

