### PR TITLE
Add option to put the library in its own namespace

### DIFF
--- a/IntervalTree.h
+++ b/IntervalTree.h
@@ -7,6 +7,9 @@
 #include <memory>
 #include <cassert>
 
+#ifdef USE_INTERVAL_TREE_NAMESPACE
+namespace interval_tree {
+#endif
 template <class Scalar, typename Value>
 class Interval {
 public:
@@ -333,5 +336,8 @@ private:
     std::unique_ptr<IntervalTree> right;
     Scalar center;
 };
+#ifdef USE_INTERVAL_TREE_NAMESPACE
+}
+#endif
 
 #endif


### PR DESCRIPTION
This allows users of the library to use names defined therein without conflicts. It is hidden behind a `#define` for backward compatibility.