### PR TITLE
Allow user-defined structs as keys to the interval tree

### DIFF
--- a/IntervalTree.h
+++ b/IntervalTree.h
@@ -35,9 +35,7 @@ public:
 
     constexpr bool operator!=(const Interval& other) const noexcept
     {
-        return start != other.start ||
-            stop != other.stop ||
-            value != other.value;
+        return !(*this == other);
     }
 };
 

--- a/IntervalTree.h
+++ b/IntervalTree.h
@@ -61,7 +61,7 @@ public:
     IntervalTree()
         : left(nullptr)
         , right(nullptr)
-        , center(Scalar{})
+        , center()
     {}
 
     ~IntervalTree() = default;

--- a/IntervalTree.h
+++ b/IntervalTree.h
@@ -61,7 +61,7 @@ public:
     IntervalTree()
         : left(nullptr)
         , right(nullptr)
-        , center(0)
+        , center(Scalar{})
     {}
 
     ~IntervalTree() = default;
@@ -93,8 +93,8 @@ public:
             std::size_t depth = 16,
             std::size_t minbucket = 64,
             std::size_t maxbucket = 512, 
-            Scalar leftextent = 0,
-            Scalar rightextent = 0)
+            Scalar leftextent = {},
+            Scalar rightextent = {})
       : left(nullptr)
       , right(nullptr)
     {
@@ -106,7 +106,7 @@ public:
         if (!ivals.empty()) {
             center = (minmaxStart.first->start + minmaxStop.second->stop) / 2;
         }
-        if (leftextent == 0 && rightextent == 0) {
+        if (leftextent == Scalar{} && rightextent == Scalar{}) {
             // sort intervals by start
             std::sort(ivals.begin(), ivals.end(), IntervalStartCmp());
         } else {
@@ -118,10 +118,10 @@ public:
             assert(is_valid().first);
             return;
         } else {
-            Scalar leftp = 0;
-            Scalar rightp = 0;
+            Scalar leftp = Scalar{};
+            Scalar rightp = Scalar{};
 
-            if (leftextent || rightextent) {
+            if (leftextent != Scalar{} || rightextent != Scalar{}) {
                 leftp = leftextent;
                 rightp = rightextent;
             } else {

--- a/IntervalTree.h
+++ b/IntervalTree.h
@@ -21,6 +21,24 @@ public:
     , stop(std::max(s, e))
     , value(v) 
     {}
+
+    Interval()
+    {
+    }
+
+    constexpr bool operator==(const Interval& other) const noexcept
+    {
+        return start == other.start &&
+            stop == other.stop &&
+            value == other.value;
+    }
+
+    constexpr bool operator!=(const Interval& other) const noexcept
+    {
+        return start != other.start ||
+            stop != other.stop ||
+            value != other.value;
+    }
 };
 
 template <class Scalar, typename Value>


### PR DESCRIPTION
Hello! Thank you for this implementation - it is extremely useful!

I'd like to propose a change that would allow custom structs to be used as keys to the tree as long as those structs have the `<`, `<=`, `>`, `>=`, `==` operators defined. 

The only code change this involves is instead of checking for equality with 0, we check for equality with the default constructor. For integral values, this does not change the behaviour. 

UPDATE:
This also now adds a default constructor and the equality/inequality operators just for ease of use