### PR TITLE
include <limits> for numeric_limits

### DIFF
--- a/IntervalTree.h
+++ b/IntervalTree.h
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <memory>
 #include <cassert>
+#include <limits>
 
 #ifdef USE_INTERVAL_TREE_NAMESPACE
 namespace interval_tree {

--- a/interval_tree_test.cpp
+++ b/interval_tree_test.cpp
@@ -2,6 +2,7 @@
 #include <thread>
 #include <chrono>
 #include <random>
+#include <limits>
 #include <time.h>
 #include <assert.h>
 #include "IntervalTree.h"


### PR DESCRIPTION
Omission of this include will cause build failures with GCC 11.
https://www.gnu.org/software/gcc/gcc-11/porting_to.html

Original bug report: https://bugs.debian.org/984212